### PR TITLE
Wrap ProcessRSS() in a try/catch so program can continue

### DIFF
--- a/PodDl/Program.cs
+++ b/PodDl/Program.cs
@@ -69,7 +69,15 @@ namespace PodDl
                         {
                             if(reader.GetAttribute("type") == "rss" && !string.IsNullOrEmpty(reader.GetAttribute("xmlUrl")))
                             {
-                                ProcessRSS(reader.GetAttribute("xmlUrl"));
+                                String xmlUrl = reader.GetAttribute("xmlUrl");
+                                try
+                                {
+                                    ProcessRSS(xmlUrl);
+                                }
+                                catch (Exception e)
+                                {
+                                    Log($"Failed reading {xmlUrl}\n{e}");
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Hi!

Added a simple `try/catch` to the `ProcessRSS()` invocation so if the RSS URL doesn't work (e.g. `404`), or if there are XML validation errors, the rest of the OPML can still be parsed.