### PR TITLE
Added Download Archive (-A) and Skip Download (-S) options, plus custom XML reader to avoid common RSS issues

### DIFF
--- a/PodDl/Download.cs
+++ b/PodDl/Download.cs
@@ -29,7 +29,5 @@ namespace PodDl
         //Fill ID3 Tags
         public string Author { get; set; }
         public string Description { get; set; }
-        
-
     }
 }

--- a/PodDl/PodDl.csproj
+++ b/PodDl/PodDl.csproj
@@ -91,6 +91,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PodDlDownloadArchive.cs" />
+    <Compile Include="PodDlXmlReader.cs" />
     <Compile Include="Documentation.cs" />
     <Compile Include="Download.cs" />
     <Compile Include="PodDlParamsObject.cs" />

--- a/PodDl/PodDlDownloadArchive.cs
+++ b/PodDl/PodDlDownloadArchive.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace PodDl
+{
+    /// <summary>
+    /// Database of downloaded podcast episodes (based on item ID)
+    /// </summary>
+    class PodDlDownloadArchive
+    {
+        /// <summary>
+        ///  Database of title-IDs
+        /// </summary>
+        private readonly HashSet<string> _archived = new HashSet<string>();
+
+        /// <summary>
+        /// Archive file
+        /// </summary>
+        private readonly string _file = @"";
+
+        /// <summary>
+        /// Creates a new instance of a PodDlDownloadArchive 
+        /// </summary>
+        /// <param name="file">Database file path</param>
+        public PodDlDownloadArchive(string file)
+        {
+            _file = file;
+
+            if (!string.IsNullOrEmpty(_file))
+            {
+                if (File.Exists(_file))
+                {
+                    string[] contents = File.ReadAllLines(_file);
+
+                    // each line is a title-ID
+                    foreach (string id in contents)
+                    {
+                        _archived.Add(id);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determines whether or not the Database has the specified title and ID
+        /// </summary>
+        /// <param name="title">Podcast title</param>
+        /// <param name="id">Podcast item ID</param>
+        /// <returns>True if the database has the specified title and ID</returns>
+        public bool HasId(string title, string id)
+        {
+            return _archived.Contains(GetId(title, id));
+        }
+
+        /// <summary>
+        /// Adds the specified title and ID to the database
+        /// </summary>
+        /// <param name="title">Podcast title</param>
+        /// <param name="id">Podcast item ID</param>
+        public void Add(string title, string id)
+        {
+            if (!HasId(title, id))
+            {
+                _archived.Add(GetId(title, id));
+            }
+        }
+
+        /// <summary>
+        /// Saves the database
+        /// </summary>
+        public void Save()
+        {
+            File.WriteAllLines(_file, _archived);
+        }
+
+        /// <summary>
+        /// Gets the unique ID for the title/ID combination
+        /// </summary>
+        /// <param name="title">Podcast title</param>
+        /// <param name="id">Podcast item ID</param>
+        /// <returns>String ID</returns>
+        private string GetId(string title, string id)
+        {
+            return $"{title}-{id}";
+        }
+    }
+}

--- a/PodDl/PodDlParamsObject.cs
+++ b/PodDl/PodDlParamsObject.cs
@@ -33,6 +33,14 @@ namespace PodDl
         [SwitchHelpText("Generate documentation html files")]
         public bool Documentation { get; set; }
 
+        [Switch("S", false, 3, false)]
+        [SwitchHelpText("Skip file download")]
+        public bool SkipFileDownload { get; set; }
+
+        [Switch("A", false, 4, false)]
+        [SwitchHelpText("Download archive file")]
+        public string DownloadArchive { get; set; }
+
         public override Dictionary<Func<bool>, string> GetParamExceptionDictionary()
         {
             Dictionary<Func<bool>, string> _exceptionChecks = new Dictionary<Func<bool>, string>();

--- a/PodDl/PodDlXmlReader.cs
+++ b/PodDl/PodDlXmlReader.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Xml;
+
+namespace PodDl
+{
+    /// <summary>
+    /// PodDL XML reader
+    /// </summary>
+    class PodDlXmlReader : XmlTextReader
+    {
+        //
+        // Constants
+        //
+        /// <summary>
+        /// Custom UTC Date/Time format
+        /// 
+        /// e.g. Wed Oct 07 08:00:07 GMT 2009
+        /// </summary>
+        private const string CustomUtcDateTimeFormat = "ddd MMM dd HH:mm:ss Z yyyy";
+
+        //
+        // Locals
+        //
+
+        /// <summary>
+        /// Whether or not we're reading the enclosure
+        /// </summary>
+        private bool readingEnclosure = false;
+
+        //
+        // Constructors
+        //
+        /// <summary>
+        /// Creates a new instance of the PodDlXmlReader with a Stream
+        /// </summary>
+        /// <param name="s">Stream</param>
+        public PodDlXmlReader(Stream s) : base(s) { }
+
+        /// <summary>
+        /// Creates a new instance of the PodDlXmlReader with an input URI
+        /// </summary>
+        /// <param name="inputUri">Input URI</param>
+        public PodDlXmlReader(string inputUri) : base(inputUri) { }
+
+        //
+        // Overrides
+        //
+        public override void ReadStartElement()
+        {
+            if (string.Equals(base.NamespaceURI, string.Empty, StringComparison.InvariantCultureIgnoreCase) &&
+                string.Equals(base.LocalName, "enclosure", StringComparison.InvariantCultureIgnoreCase))
+            {
+                readingEnclosure = true;
+            }
+            base.ReadStartElement();
+        }
+
+        public override void ReadEndElement()
+        {
+            if (readingEnclosure)
+            {
+                readingEnclosure = false;
+            }
+
+            base.ReadEndElement();
+        }
+
+        public override string ReadString()
+        {
+            // if we're reading an enclosure, do our own Date/Time parsing
+            if (readingEnclosure)
+            {
+                // read the date as a string
+                string dateString = base.ReadString();
+
+                // try to parse it
+                if (!DateTime.TryParse(dateString, out DateTime dt))
+                {
+                    dt = DateTime.ParseExact(dateString, CustomUtcDateTimeFormat, CultureInfo.InvariantCulture);
+                }
+
+                // convert to Universal time
+                return dt.ToUniversalTime().ToString("R", CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                return base.ReadString();
+            }
+        }
+
+        public override bool ReadAttributeValue()
+        {
+            // if length="none", skip it
+            if (base.LocalName.Equals("length", StringComparison.InvariantCultureIgnoreCase) &&
+                base.Value.Equals("none", StringComparison.InvariantCultureIgnoreCase)) {
+                return false;
+            }
+
+            return base.ReadAttributeValue();
+        }
+
+        public override string ReadElementContentAsString (string localName, string namespaceURI)
+        {
+            return base.ReadElementContentAsString(localName, namespaceURI);
+        }
+    }
+}


### PR DESCRIPTION
A few changes I've added to make the program run smoother for me:

1. Added a `-A` Download Archive option.  This is similar to the youtube-dl `--download-archive` option where it keeps track, by item GUIDs, of any items downloaded.  The file format is simple: `{podcast title}-{guid}`.  This can help when episodes are renamed to avoid duplicates
2. Added a `-S` Skip Downloads option.  This was mostly used for debugging, but can show you what _would_ have been downloaded for each Podcast.
3. Added a custom XML reader instead of `SyndicationFeed.Load(r)` for common XML issues I've found with some of my podcasts.  Two examples were `length="none"` and date/time being in the wrong format.  Before those feeds would be unparseable.

Apologies for having all of these in the same PR -- I could possibly break it up if desired.